### PR TITLE
Update solarwindpy to v0.1.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "solarwindpy" %}
-{% set version = "0.1.2" %}
+{% set version = "0.1.4" %}
 {% set python_min = "3.10" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/solarwindpy-{{ version }}.tar.gz
-  sha256: 922e0cb2d6ac1840cc34512d992140addbe36891baa285bec9994220df7c3dd5
+  sha256: 7b13d799d0c1399ec13e653632065f03a524cb57eeb8e2a0e2a41dab54897dfe
 
 build:
   noarch: python


### PR DESCRIPTION
## Summary
Update solarwindpy from v0.1.2 to v0.1.4

### Changes
- Update version to 0.1.4
- Update SHA256 hash for new PyPI tarball
- Includes important pandas 2.3.1 compatibility fixes

### Testing
- All existing tests pass
- Package deployed successfully to PyPI
- Fixes critical pandas compatibility issues

### Checklist
- [x] Version and hash updated
- [x] Dependencies remain unchanged (all compatible)
- [x] License file path unchanged
- [x] Recipe structure unchanged

Fixes pandas 2.3.1 breaking changes in histogram plotting functionality.