### PR TITLE
Update solarwindpy to v0.1.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "solarwindpy" %}
-{% set version = "0.1.2" %}
+{% set version = "0.1.4" %}
 {% set python_min = "3.10" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/solarwindpy-{{ version }}.tar.gz
-  sha256: 922e0cb2d6ac1840cc34512d992140addbe36891baa285bec9994220df7c3dd5
+  sha256: 7b13d799d0c1399ec13e653632065f03a524cb57eeb8e2a0e2a41dab54897dfe
 
 build:
   noarch: python


### PR DESCRIPTION
Update to latest PyPI release

This updates the solarwindpy conda-forge recipe to version 0.1.4.

**Changes:**
- Version: 0.1.2 → 0.1.4
- SHA256: Updated to match PyPI source distribution
- Dependencies: No changes (verified against pyproject.toml)

**Verification:**
- ✅ PyPI release: https://pypi.org/project/solarwindpy/0.1.4/
- ✅ GitHub release: https://github.com/blalterman/SolarWindPy/releases/tag/v0.1.4
- ✅ Source provenance verified (commit: 2d49c2edc478aafdd7e224020685932d63dc30e1)
- ✅ SHA256 matches PyPI distribution: 7b13d799d0c1399ec13e653632065f03a524cb57eeb8e2a0e2a41dab54897dfe

**Release Notes:**
- Fix: pandas 2.3.1 compatibility for Series.max(level=) methods
- Fix: matplotlib backend test case sensitivity
- Add: Comprehensive regression tests for hist2d normalizations
- Fix: Version detection issue with setuptools_scm

Tracking issue: https://github.com/blalterman/SolarWindPy/issues/396