### PR TITLE
Update solarwindpy to v0.1.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "solarwindpy" %}
-{% set version = "0.1.2" %}
+{% set version = "0.1.5" %}
 {% set python_min = "3.10" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/solarwindpy-{{ version }}.tar.gz
-  sha256: 922e0cb2d6ac1840cc34512d992140addbe36891baa285bec9994220df7c3dd5
+  sha256: e361d8e453b9a214d797b506b4c68568b0d8ef3d6eb75ff7b5a1c41b7392b6dd
 
 build:
   noarch: python


### PR DESCRIPTION
## Manual Update to v0.1.5

This PR manually updates the solarwindpy feedstock to version 0.1.5, avoiding CI configuration issues encountered with the automated bot PR (#5).

### Changes
- **Version**: 0.1.2 → 0.1.5  
- **SHA256**: Updated to match PyPI source distribution
- **CI Configuration**: Preserved (no changes to .ci_support files)

### Verification
- ✅ **PyPI Release**: https://pypi.org/project/solarwindpy/0.1.5/
- ✅ **GitHub Release**: https://github.com/blalterman/SolarWindPy/releases/tag/v0.1.5
- ✅ **SHA256 Hash**: `e361d8e453b9a214d797b506b4c68568b0d8ef3d6eb75ff7b5a1c41b7392b6dd`

### Context
The automated bot (PR #5) removed `cdt_name` from CI configuration, causing build failures. This manual PR preserves all existing CI configuration while updating only the recipe version and hash.

### Checklist
- [x] Version updated in recipe/meta.yaml
- [x] SHA256 hash verified against PyPI
- [x] CI configuration preserved
- [ ] CI checks passing
- [ ] Ready for merge

cc @conda-forge/solarwindpy