### PR TITLE
Update solarwindpy to v0.1.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,7 @@ requirements:
     - astropy-base >=5.0
     - numba >=0.57
     - tabulate >=0.9
+    - docstring-inheritance >=2.0
 
 test:
   imports:


### PR DESCRIPTION
## Update to v0.1.5

Updates solarwindpy feedstock from v0.1.4 to v0.1.5.

### Changes
- **Version**: `0.1.4` → `0.1.5`
- **SHA256**: Updated to match PyPI source distribution
- **Recipe**: No other changes

### Verification
- ✅ **PyPI Release**: https://pypi.org/project/solarwindpy/0.1.5/
- ✅ **GitHub Release**: https://github.com/blalterman/SolarWindPy/releases/tag/v0.1.5
- ✅ **SHA256**: `e361d8e453b9a214d797b506b4c68568b0d8ef3d6eb75ff7b5a1c41b7392b6dd`

### Release Notes
See full v0.1.5 changelog at: https://github.com/blalterman/SolarWindPy/blob/master/CHANGELOG.md#015---2025-11-10

**Key changes:**
- Resolved doctest failures for JOSS submission
- Removed Anaconda defaults channel (conda-forge only)
- Updated paper acknowledgements

### Checklist
- [x] Version and SHA256 updated in recipe/meta.yaml
- [x] PyPI package verified available
- [x] No dependencies changed
- [ ] CI checks passing
- [ ] Ready for merge

cc @conda-forge/solarwindpy